### PR TITLE
fix typo in cli

### DIFF
--- a/lib/ometajs/cli.js
+++ b/lib/ometajs/cli.js
@@ -26,7 +26,7 @@ exports.run = function run(options) {
 			var out = ometajs.compile(input, options);
 		} catch (e) {
 			if (e.OMeta != null && e.OMeta.line != null) {
-				console.error('Parsing error at: ' + e.OMeta.line + ':' + e.OMeta.column);
+				console.error('Parsing error at: ' + e.OMeta.line + ':' + e.OMeta.col);
 			}
 
 			deferred.reject(e);


### PR DESCRIPTION
`e.OMeta.column` is used, but `e.OMeta.col` will be [set by matchAll](https://github.com/Page-/ometa-js/blob/highlighting/lib/ometajs/core.js#L956)
