### PR TITLE
Lazy load the cli run method as it's never used by compiled grammars …

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-* Lazy load the cli run method as it's never used by compiled grammars so we can save some startup time and memory usage in those cases.
+* Lazy load uglifyjs and the cli run method as it's never used by compiled grammars so we can save some startup time and memory usage in those cases.
 
 v1.5.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+* Lazy load the cli run method as it's never used by compiled grammars so we can save some startup time and memory usage in those cases.
+
 v1.5.1
 
 * Optimise `_many`

--- a/lib/ometajs.js
+++ b/lib/ometajs.js
@@ -27,4 +27,6 @@ exports.compile = api.compile;
 exports.evalCode = api.evalCode;
 
 // CLI
-exports.run = require('./ometajs/cli').run;
+exports.run = function() {
+	require('./ometajs/cli').run.apply(null, arguments);
+};

--- a/lib/ometajs/api.js
+++ b/lib/ometajs/api.js
@@ -1,11 +1,19 @@
 var ometajs = require('../ometajs'),
-	uglify = require('uglify-js'),
+	getUglify = function() {
+		return require('uglify-js')
+	},
 	vm = require('vm'),
 	Module = require('module'),
-	compressor = uglify.Compressor({
-		sequences: false,
-		unused: false // We need this off for OMeta
-	}),
+	compressor,
+	getCompressor = function() {
+		if (!compressor) {
+			compressor = getUglify().Compressor({
+				sequences: false,
+				unused: false // We need this off for OMeta
+			})
+		}
+		return compressor
+	}
 	clone = function clone(obj) {
 		var o = {};
 
@@ -79,9 +87,9 @@ function compile(source, options) {
 	if (!options.noContext) {
 		js = wrapModule(js, options);
 	}
-	ast = uglify.parse(js);
+	ast = getUglify().parse(js);
 	ast.figure_out_scope();
-	ast = ast.transform(compressor);
+	ast = ast.transform(getCompressor());
 	js = ast.print_to_string({
 		beautify: true
 	});


### PR DESCRIPTION
…so we can save some startup time and memory usage in those cases.

Change-type: patch